### PR TITLE
handle skew<->rotation tweens

### DIFF
--- a/src/animate/MovieClip.ts
+++ b/src/animate/MovieClip.ts
@@ -583,7 +583,7 @@ export class MovieClip extends AnimateContainer
     public addTimedChild(instance: AnimateDisplayObject,
         startFrame: number,
         duration?: number,
-        keyframes?: string|{[frame: number]: TweenProps}): this
+        keyframes?: string|{[frame: number]: KeyframeData}): this
     {
         if (startFrame === undefined) // jshint ignore:line
         {
@@ -638,6 +638,34 @@ export class MovieClip extends AnimateContainer
             if (typeof keyframes === 'string')
             {
                 keyframes = utils.deserializeKeyframes(keyframes);
+            }
+            let sequenceUsesSkew = false;
+            for (const i in keyframes)
+            {
+                if (keyframes[i].kx || keyframes[i].ky)
+                {
+                    sequenceUsesSkew = true;
+                    break;
+                }
+            }
+            if(sequenceUsesSkew){
+                for (const i in keyframes)
+                {
+                    if (keyframes[i].r !== undefined)
+                    {
+                        keyframes[i].kx = keyframes[i].r;
+                        keyframes[i].ky = keyframes[i].r;
+                        if(keyframes[i].r){
+                            delete keyframes[i].r;
+                        }
+                    }
+                    if (keyframes[i].tw?.p?.r !== undefined)
+                    {
+                        keyframes[i].tw.p.kx = keyframes[i].tw.p.r;
+                        keyframes[i].tw.p.ky = keyframes[i].tw.p.r;
+                        delete keyframes[i].tw.p.r;
+                    }
+                }
             }
             for (const i in keyframes)
             {

--- a/src/animate/MovieClip.ts
+++ b/src/animate/MovieClip.ts
@@ -640,6 +640,7 @@ export class MovieClip extends AnimateContainer
                 keyframes = utils.deserializeKeyframes(keyframes);
             }
             let sequenceUsesSkew = false;
+
             for (const i in keyframes)
             {
                 if (keyframes[i].kx || keyframes[i].ky)
@@ -648,16 +649,15 @@ export class MovieClip extends AnimateContainer
                     break;
                 }
             }
-            if(sequenceUsesSkew){
+            if (sequenceUsesSkew)
+            {
                 for (const i in keyframes)
                 {
                     if (keyframes[i].r !== undefined)
                     {
                         keyframes[i].kx = keyframes[i].r;
                         keyframes[i].ky = keyframes[i].r;
-                        if(keyframes[i].r){
-                            delete keyframes[i].r;
-                        }
+                        delete keyframes[i].r;
                     }
                     if (keyframes[i].tw?.p?.r !== undefined)
                     {


### PR DESCRIPTION
If an instance has skew values modified at any point in the timeline, convert any rotation values to skew values at runtime, to allow for correct behavior when tweening between rotation and skew values. When publishing with [Animate Extension #91](https://github.com/pixijs/animate-extension/pull/91), this should only happen when intentionally using skew in Animate, but for some earlier published content, it is possible for skew and rotation to be intermixed on a timeline where only rotation was intended to be used.