### PR TITLE
Correct skewX values, don't override set skew

### DIFF
--- a/src/animate/MovieClip.ts
+++ b/src/animate/MovieClip.ts
@@ -655,14 +655,14 @@ export class MovieClip extends AnimateContainer
                 {
                     if (keyframes[i].r !== undefined)
                     {
-                        keyframes[i].kx = keyframes[i].r;
-                        keyframes[i].ky = keyframes[i].r;
+                        keyframes[i].kx = keyframes[i].kx || keyframes[i].r * -1;
+                        keyframes[i].ky = keyframes[i].ky || keyframes[i].r;
                         delete keyframes[i].r;
                     }
                     if (keyframes[i].tw?.p?.r !== undefined)
                     {
-                        keyframes[i].tw.p.kx = keyframes[i].tw.p.r;
-                        keyframes[i].tw.p.ky = keyframes[i].tw.p.r;
+                        keyframes[i].tw.p.kx = keyframes[i].tw.p.kx || keyframes[i].tw.p.r * -1;
+                        keyframes[i].tw.p.ky = keyframes[i].tw.p.ky || keyframes[i].tw.p.r;
                         delete keyframes[i].tw.p.r;
                     }
                 }


### PR DESCRIPTION
I found a couple mistakes with #125: 
SkewX was not being inverted when converted from rotation.
Some published frames have non-zero skew values and defined `0` rotation values, and the skew values were getting overridden with 0. Now, any already-set skew values take precedence rather than being overwritten by rotation.